### PR TITLE
adds estimated_delivery_at

### DIFF
--- a/lib/fedex/tracking_information.rb
+++ b/lib/fedex/tracking_information.rb
@@ -29,7 +29,7 @@ module Fedex
     }
 
     attr_reader :tracking_number, :signature_name, :service_type, :status,
-                :delivery_at, :events, :unique_tracking_number
+                :delivery_at, :events, :unique_tracking_number, :estimated_delivery_at
 
     def initialize(details = {})
       @details = details
@@ -42,6 +42,10 @@ module Fedex
 
       if details.has_key?(:actual_delivery_timestamp)
         @delivery_at = Time.parse(details[:actual_delivery_timestamp])
+      end
+
+      if details.has_key?(:estimated_delivery_timestamp)
+        @estimated_delivery_at = Time.parse(details[:estimated_delivery_timestamp])
       end
 
       @events = [details[:events]].flatten.compact.map do |event_details|


### PR DESCRIPTION
For [this PR](https://github.com/stitchfix/fashionthing/pull/980) in FashionThing, I added an `estimated_delivery_at` variable that can be accessed from the Fedex::TrackingInformation class.

I can't get all the specs in lib/fedex/track_spec.rb to pass though so not sure if I need to do anything special.

@davetron5000 @jonathandean 



