### PR TITLE
Assign owner of this Gem to rakes

### DIFF
--- a/owners.json
+++ b/owners.json
@@ -1,0 +1,7 @@
+{
+  "owners": [
+    {
+      "team": "rakes"
+    }
+  ]
+}


### PR DESCRIPTION
# Problem

Our new [RubyGem management policy](https://github.com/stitchfix/eng-wiki/blob/af4675343839ebd3d4b79ca43505fc38fe4f91c5/architecture-decisions/0008-rubygem-dependencies-will-be-managed-more-explicitly.md) requires that all gems have owners to make sure they are up-to-date.  This gem has no explicit owner.

# Solution

Create `owners.json` to document the owner of this gem, which is rakes.


        