### PR TITLE
Add additional Fedex exception types

### DIFF
--- a/lib/fedex.rb
+++ b/lib/fedex.rb
@@ -59,4 +59,8 @@ module Fedex
   class FedexRequestError < RateError; end
   # A submitted tracking number is invalid
   class InvalidTrackingNumberError < FedexRequestError; end
+  # No information is available for the submitted tracking number
+  class NoTrackingInformationAvailable < FedexRequestError; end
+  # Fedex service was unable to process the request
+  class FedexUnableToProcessRequest < FedexRequestError; end
 end

--- a/lib/fedex/request/tracking_information.rb
+++ b/lib/fedex/request/tracking_information.rb
@@ -44,6 +44,10 @@ module Fedex
             error_code = response[:track_reply][:notifications][:code]
             if invalid_tracking_number? error_code
               raise InvalidTrackingNumberError, "[#{error_code}] #{error_message} (#{@package_id})"
+            elsif no_tracking_information_available? error_code
+              raise NoTrackingInformationAvailable, "[#{error_code}] #{error_message} (#{@package_id})"
+            elsif unable_to_process_request? error_code
+              raise FedexUnableToProcessRequest, "[#{error_code}] #{error_message} (#{@package_id})"
             else
               raise FedexRequestError, "[#{error_code}] #{error_message}"
             end
@@ -101,6 +105,21 @@ module Fedex
         #  via https://www.fedex.com/en-us/developer/web-services/process.html#documentation).  These can be grep'ed
         # using pdfgrep (pdfgrep -ni 'Invalid tracking number' FedEx_WebServices_DevelopersGuide_v2019.pdf)
         error_codes = %w{6035 6037 6070 6125 6135 6140 6145 6150 6172 6173 6174 6185 30020 30030 500195 500200 500205}
+        error_codes.include? error_code
+      end
+
+      def no_tracking_information_available?(error_code)
+        error_codes = %w{6041 9040 9041 9060 500139 500140 500144 500158 500170 500173}
+        error_codes.include? error_code
+      end
+
+      def unable_to_process_request?(error_code)
+        error_codes = %w{3035 3036 3037 3038 3040 3041 3042 3045 3046 3047 3048 3049 3050 3051 3052 3053 3054 3055
+                         6310 6320 6330 7010 7020 7025
+                         9035 9045 9050 9055 9065 9070 9075 9080 9081 9082 9085 9086 9090 9095 9100 10035 10036 10037
+                         10038 10040 10041 10042 10045 10046 10047 10048 10049 10050 10051 10052 10053 10054 11035 11036
+                         11037 10040 11042 11045 11046 11047 11048 11049 11050 11051 11052 11053 11054 11060 11065 11070
+                         11070 11075 11080 11110 11502 30010 30015 30040 500141 500142 500143 500172}
         error_codes.include? error_code
       end
     end

--- a/spec/lib/fedex/track_spec.rb
+++ b/spec/lib/fedex/track_spec.rb
@@ -59,6 +59,14 @@ module Fedex
         it "raises an invalid tracking number exception" do
           expect{ fedex.track(options).first }.to raise_error(Fedex::InvalidTrackingNumberError)
         end
+
+        it "raises a no-information-available exception" do
+          expect{ fedex.track(options).first }.to raise_error(Fedex::NoTrackingInformationAvailable)
+        end
+
+        it "raises a unable-to-process-request exception" do
+          expect{ fedex.track(options).first }.to raise_error(Fedex::FedexUnableToProcessRequest)
+        end
       end
     end
   end

--- a/spec/lib/fedex/track_spec.rb
+++ b/spec/lib/fedex/track_spec.rb
@@ -47,24 +47,29 @@ module Fedex
         tracking_info.status.should == "Shipment cancelled by sender"
       end
 
-      # The following tests require constructed responses
+      # The following tests require constructed responses.  Each of these responses live in
+      # spec/vcr/fedex_tracking_information
       unless real_credentials?
         it "does not raise an exception when an event's address is missing" do
           # In the past, if an address block was missing in one of the Fedex tracking events, a
           # "NoMethodError: undefined method `[]' for nil:NilClass" exception would be raised.
+          options[:package_id] = '987654321098'
           tracking_info = fedex.track(options).first
           tracking_info.should_not be nil
         end
 
         it "raises an invalid tracking number exception" do
+          options[:package_id] = '1Z9999999999999999' # UPS tracking number
           expect{ fedex.track(options).first }.to raise_error(Fedex::InvalidTrackingNumberError)
         end
 
         it "raises a no-information-available exception" do
+          options[:package_id] = '999999999999' # A mock tracking number
           expect{ fedex.track(options).first }.to raise_error(Fedex::NoTrackingInformationAvailable)
         end
 
         it "raises a unable-to-process-request exception" do
+          options[:package_id] = '999998888777' # A mock tracking number
           expect{ fedex.track(options).first }.to raise_error(Fedex::FedexUnableToProcessRequest)
         end
       end

--- a/spec/vcr/fedex_tracking_information/shipments_with_tracking_number_does_not_raise_an_exception_when_an_event_s_address_is_missing.yml
+++ b/spec/vcr/fedex_tracking_information/shipments_with_tracking_number_does_not_raise_an_exception_when_an_event_s_address_is_missing.yml
@@ -28,7 +28,7 @@ http_interactions:
             <Minor>0</Minor>
           </Version>
           <PackageIdentifier>
-            <Value>123456789012</Value>
+            <Value>987654321098</Value>
             <Type>TRACKING_NUMBER_OR_DOORTAG</Type>
           </PackageIdentifier>
           <IncludeDetailedScans>true</IncludeDetailedScans>

--- a/spec/vcr/fedex_tracking_information/shipments_with_tracking_number_raises_a_no_information_available_exception.yml
+++ b/spec/vcr/fedex_tracking_information/shipments_with_tracking_number_raises_a_no_information_available_exception.yml
@@ -1,0 +1,73 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://gatewaybeta.fedex.com/xml/
+    body:
+      encoding: UTF-8
+      string: |-
+        <TrackRequest xmlns="http://fedex.com/ws/track/v6">
+          <WebAuthenticationDetail>
+            <UserCredential>
+              <Key>xxx</Key>
+              <Password>xxx</Password>
+            </UserCredential>
+          </WebAuthenticationDetail>
+          <ClientDetail>
+            <AccountNumber>xxx</AccountNumber>
+            <MeterNumber>xxx</MeterNumber>
+            <Localization>
+              <LanguageCode>en</LanguageCode>
+              <LocaleCode>us</LocaleCode>
+            </Localization>
+          </ClientDetail>
+          <Version>
+            <ServiceId>trck</ServiceId>
+            <Major>6</Major>
+            <Intermediate>0</Intermediate>
+            <Minor>0</Minor>
+          </Version>
+          <PackageIdentifier>
+            <Value>123456789012</Value>
+            <Type>TRACKING_NUMBER_OR_DOORTAG</Type>
+          </PackageIdentifier>
+          <IncludeDetailedScans>true</IncludeDetailedScans>
+        </TrackRequest>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 11 May 2020 16:32:48 GMT
+      Server:
+      - Apache
+      Set-Cookie:
+      - siteDC=edc; path=/; domain=.fedex.com; expires=Tue, 12-May-2020 16:32:48 GMT
+      X-Csr-Log-Transaction-Id:
+      - 01c400cf-5301-4b8b-ab6c-c340aacb87b9
+      X-Csr-Elapsed-Millis:
+      - '201'
+      Vary:
+      - Accept-Encoding
+      Responsesslprotocol:
+      - TLSv1.2
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/xml
+    body:
+      encoding: ASCII-8BIT
+      string: <?xml version="1.0" encoding="UTF-8"?><TrackReply xmlns="http://fedex.com/ws/track/v6"><HighestSeverity>ERROR</HighestSeverity><Notifications><Severity>ERROR</Severity><Source>trck</Source><Code>9040</Code><Message>This
+        tracking number cannot be found. Please check the number or contact the sender.</Message><LocalizedMessage>This
+        tracking number cannot be found. Please check the number or contact the sender.</LocalizedMessage></Notifications><Version><ServiceId>trck</ServiceId><Major>6</Major><Intermediate>0</Intermediate><Minor>0</Minor></Version></TrackReply>
+    http_version:
+  recorded_at: Mon, 11 May 2020 16:32:48 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/fedex_tracking_information/shipments_with_tracking_number_raises_a_no_information_available_exception.yml
+++ b/spec/vcr/fedex_tracking_information/shipments_with_tracking_number_raises_a_no_information_available_exception.yml
@@ -28,7 +28,7 @@ http_interactions:
             <Minor>0</Minor>
           </Version>
           <PackageIdentifier>
-            <Value>123456789012</Value>
+            <Value>999999999999</Value>
             <Type>TRACKING_NUMBER_OR_DOORTAG</Type>
           </PackageIdentifier>
           <IncludeDetailedScans>true</IncludeDetailedScans>

--- a/spec/vcr/fedex_tracking_information/shipments_with_tracking_number_raises_a_unable_to_process_request_exception.yml
+++ b/spec/vcr/fedex_tracking_information/shipments_with_tracking_number_raises_a_unable_to_process_request_exception.yml
@@ -1,0 +1,75 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://gatewaybeta.fedex.com/xml/
+    body:
+      encoding: UTF-8
+      string: |-
+        <TrackRequest xmlns="http://fedex.com/ws/track/v6">
+          <WebAuthenticationDetail>
+            <UserCredential>
+              <Key>xxx</Key>
+              <Password>xxx</Password>
+            </UserCredential>
+          </WebAuthenticationDetail>
+          <ClientDetail>
+            <AccountNumber>xxx</AccountNumber>
+            <MeterNumber>xxx</MeterNumber>
+            <Localization>
+              <LanguageCode>en</LanguageCode>
+              <LocaleCode>us</LocaleCode>
+            </Localization>
+          </ClientDetail>
+          <Version>
+            <ServiceId>trck</ServiceId>
+            <Major>6</Major>
+            <Intermediate>0</Intermediate>
+            <Minor>0</Minor>
+          </Version>
+          <PackageIdentifier>
+            <Value>123456789012</Value>
+            <Type>TRACKING_NUMBER_OR_DOORTAG</Type>
+          </PackageIdentifier>
+          <IncludeDetailedScans>true</IncludeDetailedScans>
+        </TrackRequest>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 11 May 2020 16:35:38 GMT
+      Server:
+      - Apache
+      Set-Cookie:
+      - siteDC=edc; path=/; domain=.fedex.com; expires=Tue, 12-May-2020 16:35:38 GMT
+      X-Csr-Log-Transaction-Id:
+      - c7fcabf9-5b33-4546-b34f-5230c1dbd21b
+      X-Csr-Elapsed-Millis:
+      - '2103'
+      Vary:
+      - Accept-Encoding
+      Responsesslprotocol:
+      - TLSv1.2
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/xml
+    body:
+      encoding: ASCII-8BIT
+      string: <?xml version="1.0" encoding="UTF-8"?><TrackReply xmlns="http://fedex.com/ws/track/v6"><HighestSeverity>FAILURE</HighestSeverity><Notifications><Severity>FAILURE</Severity><Source>trck</Source><Code>9045</Code><Message>Sorry,
+        we are unable to process your tracking request. Please retry later or contact
+        Customer Service at 001.800.Go.FedEx(R) 800.463.3339.</Message><LocalizedMessage>Sorry,
+        we are unable to process your tracking request. Please retry later or contact
+        Customer Service at 001.800.Go.FedEx(R) 800.463.3339.</LocalizedMessage></Notifications><Version><ServiceId>trck</ServiceId><Major>6</Major><Intermediate>0</Intermediate><Minor>0</Minor></Version></TrackReply>
+    http_version:
+  recorded_at: Mon, 11 May 2020 16:35:40 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/fedex_tracking_information/shipments_with_tracking_number_raises_a_unable_to_process_request_exception.yml
+++ b/spec/vcr/fedex_tracking_information/shipments_with_tracking_number_raises_a_unable_to_process_request_exception.yml
@@ -28,7 +28,7 @@ http_interactions:
             <Minor>0</Minor>
           </Version>
           <PackageIdentifier>
-            <Value>123456789012</Value>
+            <Value>999998888777</Value>
             <Type>TRACKING_NUMBER_OR_DOORTAG</Type>
           </PackageIdentifier>
           <IncludeDetailedScans>true</IncludeDetailedScans>

--- a/spec/vcr/fedex_tracking_information/shipments_with_tracking_number_raises_an_invalid_tracking_number_exception.yml
+++ b/spec/vcr/fedex_tracking_information/shipments_with_tracking_number_raises_an_invalid_tracking_number_exception.yml
@@ -28,7 +28,7 @@ http_interactions:
             <Minor>0</Minor>
           </Version>
           <PackageIdentifier>
-            <Value>123456789012</Value>
+            <Value>1Z9999999999999999</Value>
             <Type>TRACKING_NUMBER_OR_DOORTAG</Type>
           </PackageIdentifier>
           <IncludeDetailedScans>true</IncludeDetailedScans>


### PR DESCRIPTION
## Problem

Bugsnag [reports two kinds of errors that Fedex is returning](https://app.bugsnag.com/stitch-fix-1/fashionthing/timeline?filters[event.since][0][type]=eq&filters[event.since][0][value]=2020-05-09T07%3A00%3A00.000Z&filters[event.before][0][type]=eq&filters[event.before][0][value]=2020-05-11T07%3A00%3A00.000Z&filters[search][0][type]=eq&filters[search][0][value]=fedex) that is being raised under the generic `Fedex::FedexRequestError` exception.  These errors are broadly classified as:

* Tracking number could not be found; error codes 9040 and 9041
* Unable to process request, please try again; error code 9075

## Solution

Sub-class `Fedex::FedexRequestError` with two specific exceptions:

* `NoTrackingInformationAvailable`
* `FedexUnableToProcessRequest`

There are many error codes that Fedex may return that have identical error messages.  It is assumed that the error codes are equivalent.  Please consult the [Fedex Webservices Developer Guide](https://www.fedex.com/us/developer/downloads/pdf/2019/FedEx_WebServices_DevelopersGuide_v2019.pdf)

## Future work

There are other error codes that could be returned from Fedex, but they have not been captured yet into specific, named exceptions.  It is not currently worth the effort of enumerating every kind of exception that could occur, because not every exception may occur.  If a Fedex error gets returned in a high volume, it would then become worth it to create a specific exception to deal with the error.  This pattern has been applied to this PR.